### PR TITLE
fix: CLD-6157 updated GH action to work with node20

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,5 @@ You can update or extend any of the next files:
   * [aggregate/tests/.env](aggregate/tests/.env): GH action inputs
   * [aggregate/tests/ohp-dev-summary-json/ohp-dev-summary.json](aggregate/tests/ohp-dev-summary-json/ohp-dev-summary.json)
   * [aggregate/tests/ohp-dev2-summary-json/ohp-dev2-summary.json](aggregate/tests/ohp-dev2-summary-json/ohp-dev2-summary.json)
+
+<!-- REFRESH-2024-01-31 -->

--- a/aggregate/action.yml
+++ b/aggregate/action.yml
@@ -24,6 +24,6 @@ outputs:
     description: 'boolean true only if changes were detected in the tf plan'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
   post: 'push-artifacts.js'

--- a/summarize/action.yml
+++ b/summarize/action.yml
@@ -39,6 +39,6 @@ outputs:
     description: 'boolean true only if changes were detected in the tf plan'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
   post: 'push-artifacts.js'


### PR DESCRIPTION
- fix: LANZ-4137 [summarize] solved error when input.environment contains a "/". Now it will be replaced by "-". Updated readme
- fix: CLD-6157 updated GH action to work with node20
